### PR TITLE
Ensure destination directory exists before uploading

### DIFF
--- a/lib/kitchen/transport/speedy.rb
+++ b/lib/kitchen/transport/speedy.rb
@@ -52,6 +52,7 @@ module Kitchen
             archive_basename = ::File.basename(local) + '.tar'
             archive = ::File.join(::File.dirname(local), archive_basename)
             Mixlib::ShellOut.new(archive_locally(local, archive)).run_command.error!
+            execute(ensure_remotedir_exists(remote))
 
             logger.debug("Calling regular upload for #{archive} to #{remote}")
             super(archive, remote)

--- a/lib/kitchen/transport/speedy/version.rb
+++ b/lib/kitchen/transport/speedy/version.rb
@@ -1,7 +1,7 @@
 module Kitchen
   module Transport
     class SpeedyModule
-      VERSION = "0.1.0"
+      VERSION = "0.1.1"
     end
   end
 end

--- a/lib/kitchen/transport/speedy_ssh.rb
+++ b/lib/kitchen/transport/speedy_ssh.rb
@@ -30,6 +30,10 @@ module Kitchen
           end
         end
 
+        def ensure_remotedir_exists(remote)
+          "mkdir -p #{remote}"
+        end
+
         def archive_locally(path, archive_path)
           "tar -cf #{archive_path} -C #{::File.dirname(path)} #{::File.basename(path)}"
         end


### PR DESCRIPTION
When the remote directory doesn't exist, the upload destination is
considered to be the destination file, meaning that the untar command
will try to untar a non-existant file to a destination which is a file
and not a directory