### PR TITLE
Speedy compression v2

### DIFF
--- a/kitchen-transport-speedy.gemspec
+++ b/kitchen-transport-speedy.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen'
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec"
 end

--- a/lib/kitchen/transport/speedy.rb
+++ b/lib/kitchen/transport/speedy.rb
@@ -49,7 +49,7 @@ module Kitchen
           if ::File.directory?(local)
             file_count = ::Dir.glob(::File.join(local, '**/*')).size
             logger.debug("#{local} contains #{file_count}")
-            archive_basename = ::File.basename(local) + '.tar'
+            archive_basename = ::File.basename(local) + '.tgz'
             archive = ::File.join(::File.dirname(local), archive_basename)
             Mixlib::ShellOut.new(archive_locally(local, archive)).run_command.error!
             execute(ensure_remotedir_exists(remote))

--- a/lib/kitchen/transport/speedy_ssh.rb
+++ b/lib/kitchen/transport/speedy_ssh.rb
@@ -28,14 +28,12 @@ module Kitchen
         include SpeedyConnectionBase
 
         def valid_local_requirements?
-          !Mixlib::ShellOut.new("which tar > /dev/null").run_command.error?
-          !Mixlib::ShellOut.new("which gzip > /dev/null").run_command.error?
+          !Mixlib::ShellOut.new("which tar && which gzip > /dev/null").run_command.error?
         end
 
         def valid_remote_requirements?
           begin
-            execute("which tar > /dev/null")
-            execute("which gzip > /dev/null")
+            execute("which tar && which gzip > /dev/null")
             true
           rescue => e
             logger.debug(e)

--- a/lib/kitchen/transport/speedy_ssh.rb
+++ b/lib/kitchen/transport/speedy_ssh.rb
@@ -28,12 +28,12 @@ module Kitchen
         include SpeedyConnectionBase
 
         def valid_local_requirements?
-          !Mixlib::ShellOut.new("which tar && which gzip > /dev/null").run_command.error?
+          !Mixlib::ShellOut.new("(which tar && which gzip) > /dev/null").run_command.error?
         end
 
         def valid_remote_requirements?
           begin
-            execute("which tar && which gzip > /dev/null")
+            execute("(which tar && which gzip) > /dev/null")
             true
           rescue => e
             logger.debug(e)

--- a/lib/kitchen/transport/speedy_ssh.rb
+++ b/lib/kitchen/transport/speedy_ssh.rb
@@ -29,11 +29,13 @@ module Kitchen
 
         def valid_local_requirements?
           !Mixlib::ShellOut.new("which tar > /dev/null").run_command.error?
+          !Mixlib::ShellOut.new("which gzip > /dev/null").run_command.error?
         end
 
         def valid_remote_requirements?
           begin
             execute("which tar > /dev/null")
+            execute("which gzip > /dev/null")
             true
           rescue => e
             logger.debug(e)
@@ -45,11 +47,11 @@ module Kitchen
         end
 
         def archive_locally(path, archive_path)
-          "tar -cf #{archive_path} -C #{::File.dirname(path)} #{::File.basename(path)}"
+          "tar -czf #{archive_path} -C #{::File.dirname(path)} #{::File.basename(path)}"
         end
 
         def dearchive_remotely(archive_basename, remote)
-          "tar -xf #{::File.join(remote, archive_basename)} -C #{remote}"
+          "tar -xzf #{::File.join(remote, archive_basename)} -C #{remote}"
         end
       end
 


### PR DESCRIPTION
The goal of this patch is to do a full compress of archives before sending them over ssh.
This reduces a lot needed bandwidth; as an example, we reduce an archive of 32MB to 2MB only.

Wdyt?